### PR TITLE
Event deletion fix + silence a couple of warnings

### DIFF
--- a/apps/client/src/workspaces/spells/windows/AvatarWindow/Avatar.tsx
+++ b/apps/client/src/workspaces/spells/windows/AvatarWindow/Avatar.tsx
@@ -387,7 +387,7 @@ const AvatarFrame = ({ speechUrl, pause, unpause }) => (
   <Canvas>
     <OrbitControls target={[0.0, 1.25, 0.0]} screenSpacePanning={true} />
     <directionalLight
-      args={['0xFFFFFF']}
+      args={[0xFFFFFF]}
       position={[1.0, 1.0, 1.0]}
       intensity={0.3}
     />

--- a/apps/client/src/workspaces/spells/windows/PlaytestWindow.tsx
+++ b/apps/client/src/workspaces/spells/windows/PlaytestWindow.tsx
@@ -226,7 +226,7 @@ const Playtest = ({ tab }) => {
             <ul>{history.map(printItem)}</ul>
           </Scrollbars>
         </div>
-        <label htmlFor="" style={{ marginTop: 10 }}>
+        <label htmlFor="playtest-input" style={{ marginTop: 10 }}>
           Input
         </label>
         <Input onChange={onChange} value={value} onSend={onSend} />

--- a/apps/server/src/routes/entities.ts
+++ b/apps/server/src/routes/entities.ts
@@ -158,7 +158,7 @@ const deleteEvent = async (ctx: Koa.Context) => {
       ctx.status = 400
       return (ctx.body = 'invalid url parameter')
     }
-    const res = await database.deleteEvent(id)
+    const res = await database.deleteEvent(parseInt(id))
     return (ctx.body = true)
   } catch (e) {
     console.log(e)


### PR DESCRIPTION
- Fixes being unable to delete events from the database. Prisma expects a number for the id but it was getting a string
- Fix an empty `for` attribute on a label causing console spam whenever you moused over the playtest input field
- Replace hex color string with a hex literal