### PR TITLE
Add import shortcut to File menu

### DIFF
--- a/apps/client/src/components/MenuBar/MenuBar.tsx
+++ b/apps/client/src/components/MenuBar/MenuBar.tsx
@@ -85,6 +85,9 @@ const MenuBar = () => {
   const onOpen = () => {
     navigate('/home/all-projects')
   }
+  const onImport = () => {
+    navigate('/home/all-projects?import')
+  }
 
   const onSerialize = () => {
     if (!activeTabRef.current) return
@@ -177,6 +180,10 @@ const MenuBar = () => {
         open_spell: {
           onClick: onOpen,
           hotKey: 'option+o',
+        },
+        import_spell: {
+          onClick: onImport,
+          hotKey: 'option+i'
         },
         edit_spell: {
           onClick: onEdit,

--- a/apps/client/src/screens/HomeScreen/components/FileInput.jsx
+++ b/apps/client/src/screens/HomeScreen/components/FileInput.jsx
@@ -20,6 +20,7 @@ const FileInput = ({ loadFile }) => {
         Import...
       </button>
       <input
+        id="import"
         type="file"
         multiple="multiple"
         ref={hiddenFileInput}

--- a/apps/client/src/screens/HomeScreen/screens/AllProjects.jsx
+++ b/apps/client/src/screens/HomeScreen/screens/AllProjects.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { Scrollbars } from 'react-custom-scrollbars-2'
 
 import Icon from '../../../components/Icon/Icon'
@@ -14,6 +15,12 @@ const AllProjects = ({
   selectedSpell,
   loadFile,
 }) => {
+  useEffect(() => {
+    if (document.location.href.includes('import')) {
+      document.getElementById('import').click();
+    }
+  }, [])
+
   return (
     <Panel shadow>
       <h1>


### PR DESCRIPTION
Addresses #6. A lot of the actual functionality is tied up inside functional React components so I've opted to simply condense going to the all-projects page and clicking import into a single action.